### PR TITLE
Partition dashboard Top Composers bar by user part

### DIFF
--- a/src/dashboardComponent.js
+++ b/src/dashboardComponent.js
@@ -423,10 +423,12 @@ export class DashboardComponent {
         const textSecondary = getCssColor('--color-text-secondary');
         const otherFill = getCssColor('--color-part-fallback');
 
-        // Build the segment array for a row. When d.parts is present (the
-        // Top Musicians chart), the bar stacks by instrument left-to-right
-        // in V1 → V2 → VA → VC → OTHER order. Without d.parts (composer
-        // chart), there's a single accent-colored segment.
+        // Build the segment array for a row. Both ranked charts pass d.parts:
+        // Top Musicians breaks down by the musician's instrument, Top Composers
+        // by the user's own part. The bar stacks left-to-right in
+        // V1 → V2 → VA → VC → OTHER order. The `!d.parts` branch is a defensive
+        // fallback (single accent-colored segment) for any future caller that
+        // omits the breakdown.
         const PART_ORDER = ['V1', 'V2', 'VA', 'VC', 'OTHER'];
         const segmentsOf = (d) => {
             if (!d.parts) return [{ part: null, count: d.count, x0: 0 }];

--- a/src/dashboardComponent.js
+++ b/src/dashboardComponent.js
@@ -1,5 +1,5 @@
 import { getPartColor, getCssColor } from './config';
-import { normalizeDashboardPart, peopleKeysFor, computePartBreakdownPerMusician, computeAggregateStats } from './dataProcessor';
+import { normalizeDashboardPart, peopleKeysFor, computePartBreakdownPerMusician, computePartBreakdownPerComposer, computeAggregateStats } from './dataProcessor';
 import { DateFilterWidget } from './dateFilterWidget';
 import { MusicianNetworkComponent } from './musicianNetworkComponent';
 
@@ -327,7 +327,14 @@ export class DashboardComponent {
     renderComposerChart() {
         const rows = this.filteredRows('composer');
         const counts = d3.rollup(rows, v => v.length, d => d.composer);
-        const data = Array.from(counts, ([name, count]) => ({ name, count }));
+        // Per-composer parts breakdown so the bar stacks by the user's own
+        // part (V1/V2/VA) for that composer, mirroring the musician chart.
+        const breakdown = computePartBreakdownPerComposer(rows);
+        const data = Array.from(counts, ([name, count]) => ({
+            name,
+            count,
+            parts: breakdown.get(name),
+        }));
         this.renderRankedBars('#dashboardComposerChart', 'composer', data);
     }
 

--- a/src/dataProcessor.js
+++ b/src/dataProcessor.js
@@ -266,6 +266,24 @@ export function computePartBreakdownPerMusician(rows) {
     return result;
 }
 
+// For every composer, count how many pieces the user played in each part
+// (V1/V2/VA via normalizeDashboardPart; anything else buckets to OTHER).
+// The returned breakdown vectors sum to the composer's total piece count,
+// so the dashboard's Top Composers bar can stack by the user's own part.
+export function computePartBreakdownPerComposer(rows) {
+    const result = new Map();
+    rows.forEach(d => {
+        let parts = result.get(d.composer);
+        if (!parts) {
+            parts = { V1: 0, V2: 0, VA: 0, OTHER: 0 };
+            result.set(d.composer, parts);
+        }
+        const part = normalizeDashboardPart(d.part);
+        parts[part ?? 'OTHER']++;
+    });
+    return result;
+}
+
 // Build short display labels from canonical names. Group by first token: if
 // the first token is unique, that's the label; if two share, fall back to
 // "First L." (first-token + last-name's initial); if those still collide,

--- a/test/dataProcessor.test.mjs
+++ b/test/dataProcessor.test.mjs
@@ -17,6 +17,7 @@ import {
     disambiguateLabels,
     partFromInstrument,
     computePartBreakdownPerMusician,
+    computePartBreakdownPerComposer,
     predominantPart,
 } from '../src/dataProcessor.js';
 
@@ -740,6 +741,44 @@ describe('computePartBreakdownPerMusician', () => {
         assert.equal(sum(breakdown.get('Carol')), 2);
         assert.equal(sum(breakdown.get('Dave')), 1);
         assert.equal(sum(breakdown.get('Eve')), 1);
+    });
+});
+
+describe('computePartBreakdownPerComposer', () => {
+    const r = (composer, part) => ({ composer, part });
+
+    it('buckets each composer piece by the user part', () => {
+        const rows = [
+            r('Haydn', 'V1'),
+            r('Haydn', 'V1'),
+            r('Haydn', 'V2'),
+            r('Beethoven', 'VA'),
+        ];
+        const breakdown = computePartBreakdownPerComposer(rows);
+        assert.deepEqual(breakdown.get('Haydn'),     { V1: 2, V2: 1, VA: 0, OTHER: 0 });
+        assert.deepEqual(breakdown.get('Beethoven'), { V1: 0, V2: 0, VA: 1, OTHER: 0 });
+    });
+
+    it('folds VA1/VA2 into VA and non-canonical parts into OTHER', () => {
+        const rows = [
+            r('Mozart', 'VA1'),
+            r('Mozart', 'VA2'),
+            r('Mozart', 'VC'),  // not an upper part → OTHER
+            r('Mozart', ''),    // missing → OTHER
+        ];
+        const breakdown = computePartBreakdownPerComposer(rows);
+        assert.deepEqual(breakdown.get('Mozart'), { V1: 0, V2: 0, VA: 2, OTHER: 2 });
+    });
+
+    it('sums to the composer piece count', () => {
+        const rows = [
+            r('Haydn', 'V1'),
+            r('Haydn', 'V2'),
+            r('Haydn', 'VA'),
+            r('Haydn', 'VC'),
+        ];
+        const b = breakdown => breakdown.V1 + breakdown.V2 + breakdown.VA + breakdown.OTHER;
+        assert.equal(b(computePartBreakdownPerComposer(rows).get('Haydn')), 4);
     });
 });
 


### PR DESCRIPTION
## Summary

The dashboard's **Top 20 composers** bar chart now stacks each composer's bar by the part I played (V1/V2/VA), mirroring how the **Top 20 musicians** chart colors each bar by instrument. Same part colors as the Part stacked bar at the top of the dashboard, which doubles as the legend.

## Changes

- **`src/dataProcessor.js`** — new pure helper `computePartBreakdownPerComposer(rows)`, mirroring `computePartBreakdownPerMusician`. For each composer it counts pieces per user-part via `normalizeDashboardPart` (folding `VA1`/`VA2` → `VA`, and any non-canonical part → `OTHER`). The per-composer vectors sum to the composer's total piece count, so the stacked segments fill the bar with no gap.
- **`src/dashboardComponent.js`** — `renderComposerChart` attaches a `parts` breakdown to each composer data row. The generic `renderRankedBars` already renders per-part segmented bars (it does this for musicians), so no rendering changes were needed.
- **`test/dataProcessor.test.mjs`** — added a `computePartBreakdownPerComposer` suite covering per-part bucketing, the `VA1`/`VA2` → `VA` fold, the `OTHER` fallback, and the sum-to-count invariant.

## Behavior note

Previously, selecting a composer recolored its bar to the "selected" accent. Now the selected composer keeps its part colors and is indicated by a bold name + dimmed others — exactly how the musician chart already behaves, so the two ranked charts are now consistent.

## Testing

- `npm test` — all 104 tests pass
- `node --check` on both changed source files
- esbuild bundle builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcUPgNEbgsSx4WQe4TBMM5)_