### PR TITLE
add max-streak metric to aggregate stats, calendar, and dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ Hash routing lives in `NavigationComponent`: menu clicks set `window.location.ha
   - `parseWork`, `processRow`, `fillForward`, `createEmptyRow`
   - `normalizePlayerNames` (applies `PLAYER_ALIASES` per slot class)
   - `peopleKeysFor(d)` — canonical-name keys for unique-people counting
-  - `computeAggregateStats(rows)` — `{ pieces, uniquePieces, uniquePeople, daysPlayed }`; used by both Calendar's "Last 365 days" and the ALL tab
+  - `computeAggregateStats(rows)` — `{ pieces, uniquePieces, uniquePeople, daysPlayed, maxStreak }`; used by Calendar's "Last 365 days", the Dashboard KPI tiles, and the ALL tab. `maxStreak` is the longest run of consecutive playing days (via `longestConsecutiveRun` over DST-safe day ordinals), scoped to the passed-in slice
+  - `longestConsecutiveRun(days)` — longest run of consecutive integer day ordinals in a Set/array; returns 0 for empty
   - `normalizeDashboardPart(part)` — folds `VA1`/`VA2`/`VA…` → `VA` for the Dashboard pie/bar
   - `parseOthers`, `stripParens`, `classOf`, `canonicalize` (helpers)
   - `extractUniquePlayers` — for the Player dropdown
@@ -126,7 +127,7 @@ Classes: `upper` (V1, V2, VA, VLA — violin/viola alias as one person) and `cel
 
 ### Calendar specifics
 
-Per-year stats column shows four numbers (Pieces, Unique Pieces, People played with, Playing Days) at `cellSize*2` through `cellSize*5`, with tooltips wired via `attachStatTooltip` (works on hover and tap). The stat values + tooltip copy live in `_yearStatDefs`, shared by both layouts (horizontal right-hand column and fullscreen below-grid rows) so they can't drift. The legend SVG is sized to exactly `10 * cellSize` wide and uses CSS `width: min(170px, 17%)` + `margin-left: min(40.5px, 4.05%)` so it tracks the calendar grid's first 10 cells across all viewport widths.
+Per-year stats column shows five numbers (Pieces, Unique Pieces, People played with, Playing Days, Longest Streak) at `cellSize*2` through `cellSize*6`, with tooltips wired via `attachStatTooltip` (works on hover and tap). The stat values + tooltip copy live in `_yearStatDefs`, shared by both layouts (horizontal right-hand column and fullscreen below-grid rows) so they can't drift. The legend SVG is sized to exactly `10 * cellSize` wide and uses CSS `width: min(170px, 17%)` + `margin-left: min(40.5px, 4.05%)` so it tracks the calendar grid's first 10 cells across all viewport widths.
 
 **Fullscreen (vertical) mode**: an expand button (network-graph style: `.network-fullscreen-btn` for looks + `.calendar-fullscreen-btn` for placement) toggles a lightbox where the grid renders transposed (`renderYearGroupsVertical`) — weeks run down, days across — with the cell size fitted so a whole year fills the viewport height (54 week rows: a leap year starting Saturday spans 54 Sunday-weeks). Year columns run chronologically left→right and the container opens scrolled to its right edge, so the current year is in view and panning left walks back in time. Legend + recent stats are omitted to give the grid every pixel. Entering also calls `requestFullscreen()` on `<html>` — NOT on `#calendar`, because browsers render only the fullscreen element's subtree and the tooltip div is a `<body>` child — with every failure path silently falling back to the fixed `100dvh` overlay CSS (older iOS, installed PWAs). Esc or the collapse button exits both native fullscreen and the lightbox; a gesture-exit from *native* fullscreen deliberately leaves the lightbox open (auto-closing on `fullscreenchange` closed everything whenever a browser bounced the request). A window `resize` listener re-fits the grid on rotation / chrome show-hide.
 

--- a/build.sh
+++ b/build.sh
@@ -159,10 +159,12 @@ else
         echo "Watching static assets with fswatch (PID $!)..."
 
         # Re-run tests on any change under src/ or test/. Dot reporter so each
-        # rerun is one compact line instead of 31 ✔'s.
+        # rerun is one compact line instead of 31 ✔'s. TZ matches the npm test
+        # script (and thus CI) so timezone-sensitive tests can't pass on save
+        # but fail in CI.
         fswatch -o --latency 0.5 src test | while read _; do
             echo "[$(date +%H:%M:%S)] JS change — re-running tests..."
-            node --test --test-reporter=dot test/*.mjs || true
+            TZ=America/New_York node --test --test-reporter=dot test/*.mjs || true
         done &
         BG_PIDS="$BG_PIDS $!"
         echo "Watching src/ + test/ for tests (PID $!)..."

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "test": "node --test test/*.mjs"
+        "test": "TZ=America/New_York node --test test/*.mjs"
     }
 }

--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -799,8 +799,9 @@ export class CalendarComponent {
 
         // Full labels on desktop, dashboard-style short labels on mobile (the
         // two are toggled by a CSS media query, mirroring the dashboard tiles)
-        // so five metrics stay clear where there's room and still fit one line
-        // on a phone. The tap/hover tooltip spells out the full name either way.
+        // so five metrics stay clear where there's room and stay compact on a
+        // phone, where the row wraps (.recent-stats-row is flex-wrap: wrap).
+        // The tap/hover tooltip spells out the full name either way.
         const stats = [
             {
                 label: 'Pieces',

--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -307,7 +307,7 @@ export class CalendarComponent {
             .text(d => d > 0 ? d : "");
     }
 
-    // The four per-year stats (value + tooltip content), shared by the
+    // The five per-year stats (value + tooltip content), shared by the
     // horizontal layout's right-hand column and the vertical layout's
     // below-grid rows so the numbers and explanations can't drift apart.
     _yearStatDefs(yearQ, yearUnique, yearPeople) {
@@ -352,6 +352,22 @@ export class CalendarComponent {
                     const pct = (playingDays / denom * 100).toFixed(1);
                     return `${base}<br><br>${pct}% of days`;
                 }
+            },
+            {
+                label: "streak",
+                // The year's day-values array (yearQ) is a gap-free, ascending
+                // run of every calendar day, so the longest streak is just the
+                // longest run of value > 0 walked in order.
+                value: year => {
+                    let best = 0, run = 0;
+                    for (const d of yearQ.get(year)) {
+                        run = d.value > 0 ? run + 1 : 0;
+                        if (run > best) best = run;
+                    }
+                    return best;
+                },
+                title: year => `Longest streak in ${year}`,
+                desc: () => "Longest run of consecutive days this year with at least one whole piece logged. A streak that spans New Year's is split at the year boundary."
             }
         ];
     }
@@ -781,6 +797,9 @@ export class CalendarComponent {
         const recent = data.filter(d => d.timestamp >= cutoff && d.timestamp <= now);
         const agg = computeAggregateStats(recent);
 
+        // Short labels (mirroring the dashboard's mobile tile labels) so all
+        // five metrics fit on one line; the tap/hover tooltip spells out the
+        // full name and definition.
         const stats = [
             {
                 label: 'Pieces',
@@ -789,22 +808,28 @@ export class CalendarComponent {
                 desc: "Total quartets logged in this window. Partial-movement entries don't count — only whole pieces.",
             },
             {
-                label: 'Unique pieces',
+                label: 'Unique',
                 value: agg.uniquePieces,
                 title: `Unique pieces in the last ${days} days`,
                 desc: "Distinct works (composer + title). Repeats of the same piece collapse to one.",
             },
             {
-                label: 'Unique people',
+                label: 'People',
                 value: agg.uniquePeople,
                 title: `People played with in the last ${days} days`,
                 desc: "Distinct people logged in Player 1/2/3 and the Others? column, after alias normalization. Short names are resolved per-instrument via PLAYER_ALIASES.",
             },
             {
-                label: 'Days played',
+                label: 'Days',
                 value: agg.daysPlayed,
                 title: `Playing days in the last ${days} days`,
                 desc: 'Distinct days with at least one whole piece logged.',
+            },
+            {
+                label: 'Streak',
+                value: agg.maxStreak,
+                title: `Longest streak in the last ${days} days`,
+                desc: 'Longest run of consecutive days with at least one whole piece logged, within this window.',
             },
         ];
 

--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -797,36 +797,42 @@ export class CalendarComponent {
         const recent = data.filter(d => d.timestamp >= cutoff && d.timestamp <= now);
         const agg = computeAggregateStats(recent);
 
-        // Short labels (mirroring the dashboard's mobile tile labels) so all
-        // five metrics fit on one line; the tap/hover tooltip spells out the
-        // full name and definition.
+        // Full labels on desktop, dashboard-style short labels on mobile (the
+        // two are toggled by a CSS media query, mirroring the dashboard tiles)
+        // so five metrics stay clear where there's room and still fit one line
+        // on a phone. The tap/hover tooltip spells out the full name either way.
         const stats = [
             {
                 label: 'Pieces',
+                short: 'Pieces',
                 value: agg.pieces,
                 title: `Pieces in the last ${days} days`,
                 desc: "Total quartets logged in this window. Partial-movement entries don't count — only whole pieces.",
             },
             {
-                label: 'Unique',
+                label: 'Unique pieces',
+                short: 'Unique',
                 value: agg.uniquePieces,
                 title: `Unique pieces in the last ${days} days`,
                 desc: "Distinct works (composer + title). Repeats of the same piece collapse to one.",
             },
             {
-                label: 'People',
+                label: 'Unique people',
+                short: 'People',
                 value: agg.uniquePeople,
                 title: `People played with in the last ${days} days`,
                 desc: "Distinct people logged in Player 1/2/3 and the Others? column, after alias normalization. Short names are resolved per-instrument via PLAYER_ALIASES.",
             },
             {
-                label: 'Days',
+                label: 'Days played',
+                short: 'Days',
                 value: agg.daysPlayed,
                 title: `Playing days in the last ${days} days`,
                 desc: 'Distinct days with at least one whole piece logged.',
             },
             {
-                label: 'Streak',
+                label: 'Max streak',
+                short: 'Streak',
                 value: agg.maxStreak,
                 title: `Longest streak in the last ${days} days`,
                 desc: 'Longest run of consecutive days with at least one whole piece logged, within this window.',
@@ -838,7 +844,9 @@ export class CalendarComponent {
         const row = container.append('div').attr('class', 'recent-stats-row');
         stats.forEach(s => {
             const cell = row.append('div').attr('class', 'recent-stat');
-            cell.append('span').attr('class', 'recent-stat-label').text(`${s.label}:`);
+            // Both labels are rendered; CSS shows exactly one per viewport.
+            cell.append('span').attr('class', 'recent-stat-label recent-stat-label--long').text(`${s.label}:`);
+            cell.append('span').attr('class', 'recent-stat-label recent-stat-label--short').text(`${s.short}:`);
             cell.append('span').attr('class', 'recent-stat-value').text(s.value);
             this.attachStatTooltip(cell, () => s.title, () => s.desc);
         });

--- a/src/dashboardComponent.js
+++ b/src/dashboardComponent.js
@@ -136,7 +136,7 @@ export class DashboardComponent {
 
     // KPI tile row over the rows matching EVERY active filter (date range
     // plus any part/composer/musician selection), so the numbers describe
-    // exactly what the charts below are showing. Same four metrics as the
+    // exactly what the charts below are showing. The same metrics as the
     // calendar's "Last 365 days" block (Pieces / Unique / People / Days /
     // Streak), presented as stat tiles (label over large value) instead of
     // the calendar's inline label: value row.
@@ -185,7 +185,7 @@ export class DashboardComponent {
         // Desktop: align the row's left edge with the ranked charts' plot
         // area (where the bars start), not the screen edge — same
         // measurement the charts themselves use, re-applied on the
-        // resize-driven re-render. Mobile: no indent; the four tiles share
+        // resize-driven re-render. Mobile: no indent; the five tiles share
         // one full-width line (CSS flex: 1 1 0), since the ~270px right of
         // the chart margin can't fit them.
         const width = Math.min(MAX_DESIGN_WIDTH, this.measureWidth());

--- a/src/dashboardComponent.js
+++ b/src/dashboardComponent.js
@@ -137,8 +137,9 @@ export class DashboardComponent {
     // KPI tile row over the rows matching EVERY active filter (date range
     // plus any part/composer/musician selection), so the numbers describe
     // exactly what the charts below are showing. Same four metrics as the
-    // calendar's "Last 365 days" block, presented as stat tiles (label over
-    // large value) instead of the calendar's inline label: value row.
+    // calendar's "Last 365 days" block (Pieces / Unique / People / Days /
+    // Streak), presented as stat tiles (label over large value) instead of
+    // the calendar's inline label: value row.
     renderStats() {
         // `short` is the mobile label — the one-line tile row is tight on
         // phones, and the tap tooltip (title/desc) spells out the full name.
@@ -171,6 +172,13 @@ export class DashboardComponent {
                 value: agg.daysPlayed,
                 title: 'Playing days in the current filter',
                 desc: 'Distinct days with at least one whole piece logged.',
+            },
+            {
+                label: 'Max streak',
+                short: 'Streak',
+                value: agg.maxStreak,
+                title: 'Longest streak in the current filter',
+                desc: 'Longest run of consecutive days with at least one whole piece logged, within the current filter.',
             },
         ];
 

--- a/src/dataProcessor.js
+++ b/src/dataProcessor.js
@@ -104,14 +104,36 @@ export function normalizeDashboardPart(part) {
     return null;
 }
 
-// Floor a timestamp to its local-time day. Avoids pulling d3 in here so
-// computeAggregateStats stays unit-testable under node:test.
-function dayKey(ts) {
-    return new Date(ts.getFullYear(), ts.getMonth(), ts.getDate()).getTime();
+// Days since the Unix epoch for the local calendar day containing `ts`.
+// Feeding the local Y/M/D through Date.UTC makes consecutive calendar days
+// differ by exactly 1 regardless of DST — differencing local-midnight
+// timestamps would make a spring-forward day only 23h and misjudge adjacency.
+// Lets computeAggregateStats measure both distinct playing days and the
+// longest consecutive run. Avoids pulling d3 in here so the function stays
+// unit-testable under node:test.
+function dayOrdinal(ts) {
+    return Math.floor(Date.UTC(ts.getFullYear(), ts.getMonth(), ts.getDate()) / 86400000);
 }
 
-// Aggregate stats over an arbitrary slice of piece rows. Used by both
-// the calendar header ("Last 365 days") and the ALL tab.
+// Longest run of consecutive day ordinals in `days` (a Set or array of
+// integer day numbers, as produced by dayOrdinal). Returns 0 for empty input.
+export function longestConsecutiveRun(days) {
+    const sorted = Array.from(new Set(days)).sort((a, b) => a - b);
+    let best = 0;
+    let run = 0;
+    let prev = null;
+    for (const d of sorted) {
+        run = (prev !== null && d === prev + 1) ? run + 1 : 1;
+        if (run > best) best = run;
+        prev = d;
+    }
+    return best;
+}
+
+// Aggregate stats over an arbitrary slice of piece rows. Used by the calendar
+// header ("Last 365 days"), the dashboard KPI tiles, and the ALL tab. The
+// streak is scoped to whatever slice is passed in — a run is only counted
+// within the window/filter these rows represent.
 export function computeAggregateStats(rows) {
     const works = new Set();
     const people = new Set();
@@ -119,13 +141,14 @@ export function computeAggregateStats(rows) {
     rows.forEach(d => {
         if (d.work?.title) works.add(`${d.composer}|${d.work.title}`);
         peopleKeysFor(d).forEach(k => people.add(k));
-        if (d.timestamp) days.add(dayKey(d.timestamp));
+        if (d.timestamp) days.add(dayOrdinal(d.timestamp));
     });
     return {
         pieces: rows.length,
         uniquePieces: works.size,
         uniquePeople: people.size,
         daysPlayed: days.size,
+        maxStreak: longestConsecutiveRun(days),
     };
 }
 

--- a/src/tabComponent.js
+++ b/src/tabComponent.js
@@ -88,6 +88,7 @@ export class TabComponent {
             { label: 'Unique pieces', value: agg.uniquePieces },
             { label: 'Unique people', value: agg.uniquePeople },
             { label: 'Days played', value: agg.daysPlayed },
+            { label: 'Max streak', value: agg.maxStreak },
         ];
 
         const wrap = composerDiv.selectAll('.all-stats')

--- a/static/css/viz.css
+++ b/static/css/viz.css
@@ -756,6 +756,12 @@ body.calendar-fullscreen-open {
     color: var(--color-text-secondary);
 }
 
+/* Full labels by default; the dashboard-breakpoint media query below swaps
+   in the short ones on phones (both spans are rendered by renderRecentStats). */
+.recent-stat-label--short {
+    display: none;
+}
+
 .recent-stat-value {
     font-weight: bold;
 }
@@ -859,20 +865,24 @@ body.calendar-fullscreen-open {
     line-height: 1.2;
 }
 
-/* Mobile (mirrors MOBILE_BREAKPOINT in dashboardComponent.js): all four
+/* Mobile (mirrors MOBILE_BREAKPOINT in dashboardComponent.js): all five
    tiles share one full-width line — equal flex shares, compressed type,
    ellipsis on labels for very narrow phones. renderStats() drops the
-   plot-area indent at this width. */
+   plot-area indent at this width. The calendar's "Last 365 days" row also
+   swaps to its short labels at this same breakpoint. */
 @media only screen and (max-width: 599px) {
     .stat-tiles {
         flex-wrap: nowrap;
         gap: 6px;
     }
 
+    /* Tighter padding + smaller value than the four-tile layout used, so a
+       four-digit value (the All range) still clears the tile border when
+       five share a 320px-wide row. */
     .stat-tile {
         flex: 1 1 0;
         min-width: 0;
-        padding: 6px 8px;
+        padding: 6px 6px;
     }
 
     .stat-tile-label {
@@ -882,7 +892,15 @@ body.calendar-fullscreen-open {
     }
 
     .stat-tile-value {
-        font-size: 18px;
+        font-size: 16px;
+    }
+
+    .recent-stat-label--long {
+        display: none;
+    }
+
+    .recent-stat-label--short {
+        display: inline;
     }
 }
 

--- a/test/dataProcessor.test.mjs
+++ b/test/dataProcessor.test.mjs
@@ -9,6 +9,7 @@ import {
     normalizePlayerNames,
     peopleKeysFor,
     computeAggregateStats,
+    longestConsecutiveRun,
     normalizeDashboardPart,
     computeNodeCounts,
     computeEdgeCounts,
@@ -336,7 +337,7 @@ describe('computeAggregateStats', () => {
 
     it('returns zeroed stats for an empty array', () => {
         assert.deepEqual(computeAggregateStats([]), {
-            pieces: 0, uniquePieces: 0, uniquePeople: 0, daysPlayed: 0,
+            pieces: 0, uniquePieces: 0, uniquePeople: 0, daysPlayed: 0, maxStreak: 0,
         });
     });
 
@@ -385,6 +386,61 @@ describe('computeAggregateStats', () => {
         assert.equal(s.pieces, 3);
         assert.equal(s.uniquePieces, 1);  // only the third row contributes
         assert.equal(s.daysPlayed, 1);    // only rows with timestamps
+    });
+
+    it('maxStreak counts the longest run of consecutive playing days', () => {
+        const rows = [
+            mkRow({ timestamp: new Date(2026, 0, 1, 10, 0) }),  // Jan 1
+            mkRow({ timestamp: new Date(2026, 0, 2, 10, 0) }),  // Jan 2
+            mkRow({ timestamp: new Date(2026, 0, 3, 10, 0) }),  // Jan 3  (run of 3)
+            // gap on Jan 4
+            mkRow({ timestamp: new Date(2026, 0, 5, 10, 0) }),  // Jan 5  (run of 1)
+        ];
+        assert.equal(computeAggregateStats(rows).maxStreak, 3);
+    });
+
+    it('maxStreak treats multiple pieces on the same day as one day', () => {
+        const rows = [
+            mkRow({ timestamp: new Date(2026, 0, 1, 8, 0) }),
+            mkRow({ timestamp: new Date(2026, 0, 1, 20, 0) }),
+            mkRow({ timestamp: new Date(2026, 0, 2, 10, 0) }),
+        ];
+        assert.equal(computeAggregateStats(rows).maxStreak, 2);
+    });
+
+    it('maxStreak is 1 when every playing day is isolated', () => {
+        const rows = [
+            mkRow({ timestamp: new Date(2026, 0, 1, 10, 0) }),
+            mkRow({ timestamp: new Date(2026, 0, 3, 10, 0) }),
+            mkRow({ timestamp: new Date(2026, 0, 6, 10, 0) }),
+        ];
+        assert.equal(computeAggregateStats(rows).maxStreak, 1);
+    });
+
+    it('maxStreak stays contiguous across a spring-forward DST boundary', () => {
+        // US DST 2026: clocks jump forward on Mar 8. Mar 7→8→9 are still three
+        // consecutive calendar days even though Mar 8 is only 23h long, so the
+        // ordinal-based adjacency check must count them as a run of 3.
+        const rows = [
+            mkRow({ timestamp: new Date(2026, 2, 7, 10, 0) }),
+            mkRow({ timestamp: new Date(2026, 2, 8, 10, 0) }),
+            mkRow({ timestamp: new Date(2026, 2, 9, 10, 0) }),
+        ];
+        assert.equal(computeAggregateStats(rows).maxStreak, 3);
+    });
+});
+
+describe('longestConsecutiveRun', () => {
+    it('returns 0 for empty input', () => {
+        assert.equal(longestConsecutiveRun([]), 0);
+    });
+
+    it('finds the longest run and ignores order and duplicates', () => {
+        assert.equal(longestConsecutiveRun([5, 1, 2, 9, 3, 2, 10, 11]), 3); // 1,2,3
+    });
+
+    it('treats a single day as a run of 1', () => {
+        assert.equal(longestConsecutiveRun([42]), 1);
     });
 });
 


### PR DESCRIPTION
Introduce a fifth metric — longest run of consecutive days with at least
one whole piece logged — alongside pieces / unique pieces / unique people /
playing days.

- computeAggregateStats now returns maxStreak, computed via a new
  longestConsecutiveRun helper over DST-safe day ordinals (Date.UTC on the
  local Y/M/D). The streak is scoped to the passed-in slice, so it obeys the
  dashboard filters and the "last 365 days" window.
- Calendar "Last 365 days" block adopts the dashboard's short labels
  (Pieces / Unique / People / Days) so all five fit on one line, and adds
  Streak. Per-year stats column adds a fifth "Longest streak in <year>"
  number in both the horizontal and vertical/fullscreen layouts, split at
  the year boundary.
- Dashboard KPI tiles and the Home ALL tab both surface the new metric.
- Tests cover runs, gaps, same-day dedup, isolated days, a spring-forward
  DST boundary, and the longestConsecutiveRun helper directly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A3x1bftDa2ZPigS3yCoLSW