### PR TITLE
Show streak start date (and tie count) in streak tooltips

### DIFF
--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -760,7 +760,10 @@ export class CalendarComponent {
 
         this.tooltipDiv
             .html(html)
-            .style("display", "block");
+            .style("display", "block")
+            // Clear the stat tooltip's inline 320px cap; the CSS viewport
+            // clamp governs day tooltips (widest in the app — full plays table).
+            .style("max-width", null);
 
         // Add click handler to close button
         this.tooltipDiv.select(".tooltip-close")

--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -1,5 +1,5 @@
 import { getBegin, CALENDAR_CONFIG, getCssColor } from './config.js';
-import { peopleKeysFor, computeAggregateStats } from './dataProcessor.js';
+import { peopleKeysFor, computeAggregateStats, longestRunInfo, formatStreakStart } from './dataProcessor.js';
 import { isCurrentlyDark } from './themeManager.js';
 
 // Year math for the per-year stat tooltips. UTC-based to match the way the
@@ -356,20 +356,30 @@ export class CalendarComponent {
             {
                 label: "streak",
                 // The year's day-values array (yearQ) is a gap-free, ascending
-                // run of every calendar day, so the longest streak is just the
-                // longest run of value > 0 walked in order.
-                value: year => {
-                    let best = 0, run = 0;
-                    for (const d of yearQ.get(year)) {
-                        run = d.value > 0 ? run + 1 : 0;
-                        if (run > best) best = run;
-                    }
-                    return best;
-                },
+                // run of every calendar day, so streaks are runs of consecutive
+                // indices among the value > 0 days — longestRunInfo on those
+                // indices gives the length, tie count, and start date at once.
+                value: year => this._yearStreak(yearQ, year).length,
                 title: year => `Longest streak in ${year}`,
-                desc: () => "Longest run of consecutive days this year with at least one whole piece logged. A streak that spans New Year's is split at the year boundary."
+                desc: year => {
+                    const base = "Longest run of consecutive days this year with at least one whole piece logged. A streak that spans New Year's is split at the year boundary.";
+                    const started = formatStreakStart(this._yearStreak(yearQ, year));
+                    return started ? `${base}<br><br>Started: ${started}` : base;
+                }
             }
         ];
+    }
+
+    // Streak info for one year: longestRunInfo over the indices of played
+    // days in the year's gap-free day array, with the start index translated
+    // back to that day's date. The dates are read via getUTC* accessors
+    // downstream, matching how the calendar assigns days everywhere else.
+    _yearStreak(yearQ, year) {
+        const days = yearQ.get(year);
+        const played = [];
+        days.forEach((d, i) => { if (d.value > 0) played.push(i); });
+        const info = longestRunInfo(played);
+        return { ...info, start: info.start === null ? null : days[info.start].date };
     }
 
     // Fullscreen layout: the calendar transposed — days of week across the
@@ -796,6 +806,7 @@ export class CalendarComponent {
         const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
         const recent = data.filter(d => d.timestamp >= cutoff && d.timestamp <= now);
         const agg = computeAggregateStats(recent);
+        const streakStart = formatStreakStart(agg.maxStreakInfo);
 
         // Full labels on desktop, dashboard-style short labels on mobile (the
         // two are toggled by a CSS media query, mirroring the dashboard tiles)
@@ -836,7 +847,8 @@ export class CalendarComponent {
                 short: 'Streak',
                 value: agg.maxStreak,
                 title: `Longest streak in the last ${days} days`,
-                desc: 'Longest run of consecutive days with at least one whole piece logged, within this window.',
+                desc: 'Longest run of consecutive days with at least one whole piece logged, within this window.'
+                    + (streakStart ? `<br><br>Started: ${streakStart}` : ''),
             },
         ];
 

--- a/src/dashboardComponent.js
+++ b/src/dashboardComponent.js
@@ -1,5 +1,5 @@
 import { getPartColor, getCssColor } from './config';
-import { normalizeDashboardPart, peopleKeysFor, computePartBreakdownPerMusician, computePartBreakdownPerComposer, computeAggregateStats } from './dataProcessor';
+import { normalizeDashboardPart, peopleKeysFor, computePartBreakdownPerMusician, computePartBreakdownPerComposer, computeAggregateStats, formatStreakStart } from './dataProcessor';
 import { DateFilterWidget } from './dateFilterWidget';
 import { MusicianNetworkComponent } from './musicianNetworkComponent';
 
@@ -144,6 +144,7 @@ export class DashboardComponent {
         // `short` is the mobile label — the one-line tile row is tight on
         // phones, and the tap tooltip (title/desc) spells out the full name.
         const agg = computeAggregateStats(this.filteredRows(null));
+        const streakStart = formatStreakStart(agg.maxStreakInfo);
         const stats = [
             {
                 label: 'Pieces',
@@ -178,7 +179,8 @@ export class DashboardComponent {
                 short: 'Streak',
                 value: agg.maxStreak,
                 title: 'Longest streak in the current filter',
-                desc: 'Longest run of consecutive days with at least one whole piece logged, within the current filter.',
+                desc: 'Longest run of consecutive days with at least one whole piece logged, within the current filter.'
+                    + (streakStart ? `<br><br>Started: ${streakStart}` : ''),
             },
         ];
 

--- a/src/dataProcessor.js
+++ b/src/dataProcessor.js
@@ -118,16 +118,46 @@ function dayOrdinal(ts) {
 // Longest run of consecutive day ordinals in `days` (a Set or array of
 // integer day numbers, as produced by dayOrdinal). Returns 0 for empty input.
 export function longestConsecutiveRun(days) {
+    return longestRunInfo(days).length;
+}
+
+// Like longestConsecutiveRun, but also reports how many distinct runs tie
+// for the longest and where the most recent of them begins. Returns
+// { length, count, start } with `start` in the same units as the input
+// (null for empty input). Feeds the streak tooltips.
+export function longestRunInfo(days) {
     const sorted = Array.from(new Set(days)).sort((a, b) => a - b);
-    let best = 0;
-    let run = 0;
-    let prev = null;
+    let best = 0, count = 0, bestStart = null;
+    let run = 0, runStart = null, prev = null;
     for (const d of sorted) {
-        run = (prev !== null && d === prev + 1) ? run + 1 : 1;
-        if (run > best) best = run;
+        if (prev !== null && d === prev + 1) {
+            run += 1;
+        } else {
+            run = 1;
+            runStart = d;
+        }
+        // A run passes through each length exactly once, so `run === best`
+        // fires at most once per run: a later run tying the record bumps the
+        // count and takes over `start` (most recent wins); beating the
+        // record resets both.
+        if (run > best) {
+            best = run; count = 1; bestStart = runStart;
+        } else if (run === best) {
+            count += 1; bestStart = runStart;
+        }
         prev = d;
     }
-    return best;
+    return { length: best, count, start: bestStart };
+}
+
+// "M/D/YYYY" start date of the most recent longest streak, with the number
+// of equal-length streaks appended when there's a tie — e.g. "7/10/2026 (3)".
+// Empty string when there's no streak. `start` must be a Date whose UTC
+// fields hold the local calendar day (the maxStreakInfo convention below).
+export function formatStreakStart({ count, start }) {
+    if (!start) return '';
+    const date = `${start.getUTCMonth() + 1}/${start.getUTCDate()}/${start.getUTCFullYear()}`;
+    return count > 1 ? `${date} (${count})` : date;
 }
 
 // Aggregate stats over an arbitrary slice of piece rows. Used by the calendar
@@ -143,12 +173,20 @@ export function computeAggregateStats(rows) {
         peopleKeysFor(d).forEach(k => people.add(k));
         if (d.timestamp) days.add(dayOrdinal(d.timestamp));
     });
+    const streak = longestRunInfo(days);
     return {
         pieces: rows.length,
         uniquePieces: works.size,
         uniquePeople: people.size,
         daysPlayed: days.size,
-        maxStreak: longestConsecutiveRun(days),
+        maxStreak: streak.length,
+        // Start of the most recent longest run as a Date at UTC midnight of
+        // the local calendar day (read it with getUTC* accessors — inverse
+        // of dayOrdinal), plus how many runs tie for that length.
+        maxStreakInfo: {
+            count: streak.count,
+            start: streak.start === null ? null : new Date(streak.start * 86400000),
+        },
     };
 }
 

--- a/src/musicianNetworkComponent.js
+++ b/src/musicianNetworkComponent.js
@@ -904,7 +904,10 @@ export class MusicianNetworkComponent {
     _showTooltip(event, html) {
         this.tooltipDiv
             .html(`<span class="tooltip-close">&times;</span>${html}`)
-            .style('display', 'block');
+            .style('display', 'block')
+            // Clear the inline 320px cap the dashboard/ALL-tab stat tooltips
+            // set on the shared #tooltip div.
+            .style('max-width', null);
         this.tooltipDiv.select('.tooltip-close')
             .on('click', () => this._hideTooltip());
         this._positionTooltip(event);

--- a/src/tabComponent.js
+++ b/src/tabComponent.js
@@ -1,6 +1,6 @@
 import { COMPOSERS, ALL_WORKS, ALL_TAB, generateQuartetRouletteUrl, getPetersVolume, isMiscTab, isAllTab, getComposersForTab, getWorksForTab, getComposerForWork, getOriginalWorkTitle } from './catalog';
 import { getBegin, getPartColor, getCssColor } from './config';
-import { createEmptyRow, computeAggregateStats } from './dataProcessor';
+import { createEmptyRow, computeAggregateStats, formatStreakStart } from './dataProcessor';
 
 export class TabComponent {
     constructor(tableComponent) {
@@ -22,9 +22,11 @@ export class TabComponent {
             if (cls?.contains('network-node') || cls?.contains('network-edge')
                 || cls?.contains('matrix-cell') || cls?.contains('matrix-label')
                 || cls?.contains('network-arc') || cls?.contains('network-chord')) return;
-            // Dashboard stat tiles show their explainer tooltip on click; the
-            // click target is a child span, so match via closest().
+            // Dashboard stat tiles and the ALL tab's stat cells show their
+            // explainer tooltip on click; the click target is a child span,
+            // so match via closest().
             if (e.target.closest?.('#dashboardStats .stat-tile')) return;
+            if (e.target.closest?.('.all-stat')) return;
             this.hideTooltip();
         });
     }
@@ -83,12 +85,41 @@ export class TabComponent {
 
     updateAllTabContent(composerDiv, filteredData) {
         const agg = computeAggregateStats(filteredData);
+        const streakStart = formatStreakStart(agg.maxStreakInfo);
+        // Same explainer copy as the dashboard's KPI tiles — both describe
+        // the slice matching the current filters.
         const stats = [
-            { label: 'Pieces', value: agg.pieces },
-            { label: 'Unique pieces', value: agg.uniquePieces },
-            { label: 'Unique people', value: agg.uniquePeople },
-            { label: 'Days played', value: agg.daysPlayed },
-            { label: 'Max streak', value: agg.maxStreak },
+            {
+                label: 'Pieces',
+                value: agg.pieces,
+                title: 'Pieces in the current filter',
+                desc: "Total quartets logged in this window. Partial-movement entries don't count — only whole pieces.",
+            },
+            {
+                label: 'Unique pieces',
+                value: agg.uniquePieces,
+                title: 'Unique pieces in the current filter',
+                desc: 'Distinct works (composer + title). Repeats of the same piece collapse to one.',
+            },
+            {
+                label: 'Unique people',
+                value: agg.uniquePeople,
+                title: 'People played with in the current filter',
+                desc: 'Distinct people logged in Player 1/2/3 and the Others? column, after alias normalization. Short names are resolved per-instrument via PLAYER_ALIASES.',
+            },
+            {
+                label: 'Days played',
+                value: agg.daysPlayed,
+                title: 'Playing days in the current filter',
+                desc: 'Distinct days with at least one whole piece logged.',
+            },
+            {
+                label: 'Max streak',
+                value: agg.maxStreak,
+                title: 'Longest streak in the current filter',
+                desc: 'Longest run of consecutive days with at least one whole piece logged, within the current filter.'
+                    + (streakStart ? `<br><br>Started: ${streakStart}` : ''),
+            },
         ];
 
         const wrap = composerDiv.selectAll('.all-stats')
@@ -111,6 +142,11 @@ export class TabComponent {
             });
         cells.select('.all-stat-label').text(d => `${d.label}:`);
         cells.select('.all-stat-value').text(d => d.value);
+        cells
+            .style('cursor', 'pointer')
+            .on('mouseenter', (event, d) => this.showStatTooltip(event, d))
+            .on('mouseleave', () => this.hideTooltip())
+            .on('click', (event, d) => this.showStatTooltip(event, d));
 
         // Reuse the existing data table by wrapping the flat array in the
         // shape updateDataTable expects.
@@ -360,6 +396,17 @@ export class TabComponent {
         return getPartColor(part);
     }
 
+    // Explainer tooltip for the ALL tab's stat cells (same title/desc shape
+    // as the dashboard's KPI tiles).
+    showStatTooltip(event, stat) {
+        this.tooltipDiv
+            .html(`<span class="tooltip-close">&times;</span><h4>${stat.title}</h4><p>${stat.desc}</p>`)
+            .style('display', 'block')
+            .style('max-width', '320px');
+        this.tooltipDiv.select('.tooltip-close').on('click', () => this.hideTooltip());
+        this.positionTooltip(event);
+    }
+
     showTooltip(event, d) {
         if (!d) return;
 
@@ -382,7 +429,10 @@ export class TabComponent {
 
         this.tooltipDiv
             .html(html)
-            .style("display", "block");
+            .style("display", "block")
+            // Clear the stat tooltip's inline 320px cap; the CSS viewport
+            // clamp governs work tooltips.
+            .style("max-width", null);
 
         // Add click handler to close button
         this.tooltipDiv.select(".tooltip-close")

--- a/test/dataProcessor.test.mjs
+++ b/test/dataProcessor.test.mjs
@@ -10,6 +10,8 @@ import {
     peopleKeysFor,
     computeAggregateStats,
     longestConsecutiveRun,
+    longestRunInfo,
+    formatStreakStart,
     normalizeDashboardPart,
     computeNodeCounts,
     computeEdgeCounts,
@@ -338,6 +340,7 @@ describe('computeAggregateStats', () => {
     it('returns zeroed stats for an empty array', () => {
         assert.deepEqual(computeAggregateStats([]), {
             pieces: 0, uniquePieces: 0, uniquePeople: 0, daysPlayed: 0, maxStreak: 0,
+            maxStreakInfo: { count: 0, start: null },
         });
     });
 
@@ -417,6 +420,21 @@ describe('computeAggregateStats', () => {
         assert.equal(computeAggregateStats(rows).maxStreak, 1);
     });
 
+    it('maxStreakInfo reports the most recent start and the tie count', () => {
+        const rows = [
+            mkRow({ timestamp: new Date(2026, 0, 1, 10, 0) }),  // Jan 1-2
+            mkRow({ timestamp: new Date(2026, 0, 2, 10, 0) }),
+            mkRow({ timestamp: new Date(2026, 1, 10, 10, 0) }), // Feb 10-11
+            mkRow({ timestamp: new Date(2026, 1, 11, 10, 0) }),
+        ];
+        const info = computeAggregateStats(rows).maxStreakInfo;
+        assert.equal(info.count, 2);
+        // Local calendar day lands in the Date's UTC fields (dayOrdinal inverse).
+        assert.equal(info.start.getUTCFullYear(), 2026);
+        assert.equal(info.start.getUTCMonth(), 1);
+        assert.equal(info.start.getUTCDate(), 10);
+    });
+
     it('maxStreak stays contiguous across a spring-forward DST boundary', () => {
         // US DST 2026: clocks jump forward on Mar 8. Mar 7→8→9 are still three
         // consecutive calendar days even though Mar 8 is only 23h long, so the
@@ -441,6 +459,49 @@ describe('longestConsecutiveRun', () => {
 
     it('treats a single day as a run of 1', () => {
         assert.equal(longestConsecutiveRun([42]), 1);
+    });
+});
+
+describe('longestRunInfo', () => {
+    it('returns a zeroed record for empty input', () => {
+        assert.deepEqual(longestRunInfo([]), { length: 0, count: 0, start: null });
+    });
+
+    it('reports length, count 1, and start for a single longest run', () => {
+        // 1,2,3 is the unique longest run; 10,11 is shorter.
+        assert.deepEqual(longestRunInfo([10, 11, 1, 2, 3]), { length: 3, count: 1, start: 1 });
+    });
+
+    it('counts ties and reports the most recent start', () => {
+        // Two runs of length 2 (1-2 and 7-8): count both, start at the later one.
+        assert.deepEqual(longestRunInfo([1, 2, 7, 8]), { length: 2, count: 2, start: 7 });
+    });
+
+    it('does not double-count a run that grows past an earlier tie', () => {
+        // 1-2 ties at length 2 as 7-8-9 passes through it, but 7-8-9 then
+        // beats the record — one run of 3, starting at 7.
+        assert.deepEqual(longestRunInfo([1, 2, 7, 8, 9]), { length: 3, count: 1, start: 7 });
+    });
+
+    it('ignores order and duplicates', () => {
+        assert.deepEqual(longestRunInfo([8, 2, 1, 7, 2, 8]), { length: 2, count: 2, start: 7 });
+    });
+});
+
+describe('formatStreakStart', () => {
+    // UTC-noon avoids any ambiguity about which UTC calendar day the fields read.
+    const utc = (y, m, d) => new Date(Date.UTC(y, m, d, 12));
+
+    it('returns empty string when there is no streak', () => {
+        assert.equal(formatStreakStart({ count: 0, start: null }), '');
+    });
+
+    it('formats a lone longest streak as M/D/YYYY', () => {
+        assert.equal(formatStreakStart({ count: 1, start: utc(2026, 6, 10) }), '7/10/2026');
+    });
+
+    it('appends the tie count when multiple streaks share the length', () => {
+        assert.equal(formatStreakStart({ count: 3, start: utc(2026, 6, 10) }), '7/10/2026 (3)');
     });
 });
 


### PR DESCRIPTION
## Summary

The streak stat's tooltip now says when the streak happened. Every streak tooltip gains a `Started:` line showing the streak's start date — and when multiple streaks tie for the max length, the most recent start date plus the tie count, e.g. `Started: 7/10/2026 (3)`.

- **`dataProcessor.js`**: new `longestRunInfo(days)` returns `{ length, count, start }` (most-recent-start-wins on ties); `longestConsecutiveRun` is now a thin wrapper over it, so existing behavior is unchanged. `computeAggregateStats` exposes `maxStreakInfo: { count, start: Date|null }` alongside the untouched `maxStreak`, and `formatStreakStart()` renders the `7/10/2026 (3)` format.
- **Calendar per-year column**: the streak def's inline run-walk is replaced by `_yearStreak()`, which feeds the played-day *indices* of the year's gap-free day array through the shared `longestRunInfo` — one run-finding implementation everywhere, and the start date falls out for free. Both the horizontal and fullscreen layouts get it via the shared `_yearStatDefs`.
- **Calendar "Last 365 days" + dashboard KPI tile**: one-line appends via `agg.maxStreakInfo`.
- **ALL tab**: was the only streak site with no tooltip at all, so its five stat cells gain the dashboard-style tap/hover explainer tooltips (same copy, reusing `TabComponent`'s `#tooltip` plumbing), streak line included. The tap-outside dismiss listener gets an `.all-stat` exemption mirroring the dashboard-tile one, and the work-square tooltip now clears the stat tooltip's inline `max-width` so it isn't capped afterward.

## Test plan

- New tests for `longestRunInfo` (ties, most-recent start, a run growing past an earlier tie, order/duplicate insensitivity), `formatStreakStart`, and `maxStreakInfo` in `computeAggregateStats`; empty-stats shape test updated.
- `npm test`: 120 pass. Full esbuild bundle compiles with prod flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)