### PR TITLE
bump action pins to node24 releases; add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keeps the SHA-pinned GitHub Actions current: Dependabot understands
+# `uses: owner/action@<sha> # vX.Y.Z` pins, preserves the pin style, and
+# opens a PR (which test.yml then checks) whenever an action releases.
+# Without this, pinned actions never move — how the workflows ended up on
+# node20-era releases the runners now warn about.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One PR per week covering all action bumps, not one PR per action.
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -66,10 +66,10 @@ jobs:
         run: ./build.sh --prod
 
       - name: Setup Pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./last_deploy
 
@@ -82,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'


### PR DESCRIPTION
Fixes the Node 20 deprecation annotations on every run. Two parts:

- **Bump every SHA-pinned action to its current release** (checkout v4.4.0→v7.0.1, setup-node v4.4.0→v7.0.0, configure-pages v4→v6, upload-pages-artifact v3→v5, deploy-pages v4→v5). The warning was about the actions' own declared Node runtimes (`runs.using: node20`), which our `.nvmrc`/engines pin doesn't control; SHA pinning (deliberately) froze them. SHAs resolved from the release tags via the GitHub API.
- **Add `.github/dependabot.yml`** for the `github-actions` ecosystem: weekly, grouped into one PR, preserving the SHA-pin + version-comment style — so action freshness becomes a reviewed PR instead of a deploy-log annotation someone has to notice.

The Pages trio (configure-pages v6 / upload-pages-artifact v5 / deploy-pages v5) are designed to pair; setup-node v7 keeps `node-version-file` + npm cache support. PR CI exercises checkout/setup-node directly; the Pages actions get exercised by the first post-merge deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)