### PR TITLE
build: never publish md/CLAUDE.md as a site page

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,9 @@ copy_assets() {
     fi
     pushd md/ > /dev/null
     for md in *.md; do
+        # CLAUDE.md here would be agent guidance scoped to this directory,
+        # not a site page — every other *.md in md/ is published.
+        [ "$md" = "CLAUDE.md" ] && continue
         f=$(basename "$md" .md)
         pandoc -f gfm+attributes+implicit_figures -t html5 -o "$deploy_abs/$f.html" "$md" \
             --css github-markdown.css \


### PR DESCRIPTION
`copy_assets()` renders **every** `md/*.md` through pandoc into `$DEPLOY`:

```bash
pushd md/ > /dev/null
for md in *.md; do
    f=$(basename "$md" .md)
    pandoc ... -o "$deploy_abs/$f.html" "$md"
```

So a `CLAUDE.md` placed in `md/` — the natural home for guidance scoped to that directory — would be rendered to `last_deploy/CLAUDE.html` and deployed to **log.quartetroulette.com/CLAUDE.html**. Three lines guard against it.

### Verification

A/B with a scratch `md/CLAUDE.md` in place, running `./build.sh --prod`:

| | `last_deploy/` contents |
|---|---|
| without the guard | about, howto, index, setup, **CLAUDE.html** ← leaks |
| with the guard | about, howto, index, setup |

### Notes

- **Preventative** — no `md/CLAUDE.md` exists today, so this changes nothing about the current build output.
- It's a prerequisite for moving the pandoc section of `CLAUDE.md` into `md/`, where it would load only when working under that directory. That larger change is tracked separately.
- `static/` is unaffected: `build.sh` copies it file by file (`cp static/css/viz.css`, `cp static/data/*.json`, …), not wholesale, so a `static/CLAUDE.md` was never at risk.
- `md/md2html.sh` had the same loop but was deleted in the architecture-hardening pass, so only `build.sh` needs this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)