### PR TITLE
derive calendar per-year stats from computeAggregateStats

### DIFF
--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { getBegin, CALENDAR_CONFIG, getCssColor } from './config.js';
-import { peopleKeysFor, workKey, workPartKey, computeAggregateStats, longestRunInfo, formatStreakStart } from './dataProcessor.js';
+import { computeAggregateStats, formatStreakStart } from './dataProcessor.js';
 import { isCurrentlyDark } from './themeManager.js';
 import { escapeHtml } from './escapeHtml.js';
 import { tooltip } from './tooltip.js';
@@ -135,27 +135,15 @@ export class CalendarComponent {
         // Group by year
         const years = d3.groups(days, d => d.date.getUTCFullYear()).reverse();
 
-        // Per-year count of unique pieces (composer + work title).
-        const yearUnique = new Map(years.map(([y]) => [y, new Set()]));
-        // Per-year count of unique work + part combinations (workPartKey:
-        // raw part value, so quintet VA and VA2 rows count separately).
-        const yearParts = new Map(years.map(([y]) => [y, new Set()]));
-        // Per-year count of unique people played with (post-alias-normalization).
-        const yearPeople = new Map(years.map(([y]) => [y, new Set()]));
-        sessions.forEach((sessionList, dayTs) => {
-            const year = new Date(dayTs).getUTCFullYear();
-            const uniq = yearUnique.get(year);
-            const parts = yearParts.get(year);
-            const people = yearPeople.get(year);
-            if (!uniq || !parts || !people) return;
-            sessionList.forEach(s => {
-                const wk = workKey(s);
-                if (wk) uniq.add(wk);
-                const pk = workPartKey(s);
-                if (pk) parts.add(pk);
-                peopleKeysFor(s).forEach(k => people.add(k));
-            });
-        });
+        // Per-year aggregate stats, derived from the same computeAggregateStats
+        // that feeds the ALL tab, Dashboard KPI tiles, and "Last 365 days"
+        // header — so the per-year numbers agree with the rest of the app by
+        // construction. Rows are bucketed into years by the same expression
+        // the grid uses for days (d3.timeDay(...).getUTCFullYear()), so the
+        // stat column can't disagree with the band it renders beside. A year
+        // slice can't span years, so the streak splits at New Year's for free.
+        const yearStats = new Map(d3.groups(data, d => d3.timeDay(d.timestamp).getUTCFullYear())
+            .map(([y, rows]) => [y, computeAggregateStats(rows)]));
 
         const container = d3.select("#calendar");
 
@@ -171,9 +159,7 @@ export class CalendarComponent {
             countDay,
             color,
             sessions,
-            yearUnique,
-            yearParts,
-            yearPeople
+            yearStats
         };
 
         // Fullscreen: transposed layout — weeks run down, days across, one
@@ -338,8 +324,7 @@ export class CalendarComponent {
 
         // Per-year stats (shifted right to make room for day-of-week totals).
         // One stacked bare number per stat; the tooltip explains which is which.
-        const yearQ = new Map(years);
-        const statDefs = this._yearStatDefs(yearQ, config);
+        const statDefs = this._yearStatDefs(config);
         // The year band is a fixed CALENDAR_CONFIG.height (10 cells) with
         // stats at cellSize*(2 + i): rows 0..6 fit, an eighth would silently
         // spill into the next year's band. Fail loudly in dev instead.
@@ -380,85 +365,71 @@ export class CalendarComponent {
     // The six per-year stats (value + tooltip content), shared by the
     // horizontal layout's right-hand column and the vertical layout's
     // below-grid rows so the numbers and explanations can't drift apart.
-    // Takes the render config (not positional Maps): the three unique-count
-    // Maps are interchangeable `Map<year, Set>`s, so positional args made a
-    // silent transposition possible at every call site.
-    _yearStatDefs(yearQ, { yearUnique, yearParts, yearPeople }) {
+    // Every value reads from config.yearStats (per-year computeAggregateStats
+    // output), so these are the same six metrics — computed by the same code
+    // — as the ALL tab, Dashboard, and "Last 365 days" header. Only the
+    // tooltip copy and the current-year projections are calendar-specific.
+    _yearStatDefs({ yearStats }) {
+        // Grid year bands can cover a data-free year; fall back to zeros.
+        const empty = computeAggregateStats([]);
+        const agg = year => yearStats.get(year) ?? empty;
         return [
             {
                 label: "pieces",
-                value: year => d3.sum(yearQ.get(year), d => d.value),
+                value: year => agg(year).pieces,
                 title: year => `Pieces played in ${year}`,
                 desc: year => {
                     const base = "Total quartets logged this year. Partial-movement entries (titles containing ':', e.g. '44#1:I') don't count — only whole pieces.";
                     const today = new Date();
                     if (year !== today.getUTCFullYear()) return base;
-                    const pieces = d3.sum(yearQ.get(year), d => d.value);
                     const elapsed = Math.max(1, dayOfYearUTC(today));
-                    const projected = Math.floor(pieces * daysInYear(year) / elapsed);
+                    const projected = Math.floor(agg(year).pieces * daysInYear(year) / elapsed);
                     return `${base}<br><br>On track for: ${projected}`;
                 }
             },
             {
                 label: "unique",
-                value: year => yearUnique.get(year)?.size ?? 0,
+                value: year => agg(year).uniquePieces,
                 title: year => `Unique pieces played in ${year}`,
                 desc: () => "Distinct works (composer + title) logged this year. Partial-movement entries don't count, so repeats of the same piece collapse to one."
             },
             {
                 label: "parts",
-                value: year => yearParts.get(year)?.size ?? 0,
+                value: year => agg(year).uniqueParts,
                 title: year => `Unique parts played in ${year}`,
                 desc: () => uniquePartsDesc(' this year')
             },
             {
                 label: "people",
-                value: year => yearPeople.get(year)?.size ?? 0,
+                value: year => agg(year).uniquePeople,
                 title: year => `People played with in ${year}`,
                 desc: () => "Distinct people logged in Player 1/2/3 and the Others? column this year, after alias normalization. Short names are resolved per-instrument via PLAYER_ALIASES, so 'Jen' on violin and 'Jen' on cello can map to different people."
             },
             {
                 label: "days",
-                value: year => d3.sum(yearQ.get(year), d => d.value > 0 ? 1 : 0),
+                value: year => agg(year).daysPlayed,
                 title: year => `Playing days in ${year}`,
                 desc: year => {
                     const base = "Number of distinct days this year with at least one whole piece logged. Partial movements alone don't count as a playing day.";
-                    const playingDays = d3.sum(yearQ.get(year), d => d.value > 0 ? 1 : 0);
                     const today = new Date();
                     const denom = year === today.getUTCFullYear()
                         ? Math.max(1, dayOfYearUTC(today))
                         : daysInYear(year);
-                    const pct = (playingDays / denom * 100).toFixed(1);
+                    const pct = (agg(year).daysPlayed / denom * 100).toFixed(1);
                     return `${base}<br><br>${pct}% of days`;
                 }
             },
             {
                 label: "streak",
-                // The year's day-values array (yearQ) is a gap-free, ascending
-                // run of every calendar day, so streaks are runs of consecutive
-                // indices among the value > 0 days — longestRunInfo on those
-                // indices gives the length, tie count, and start date at once.
-                value: year => this._yearStreak(yearQ, year).length,
+                value: year => agg(year).maxStreak,
                 title: year => `Longest streak in ${year}`,
                 desc: year => {
                     const base = "Longest run of consecutive days this year with at least one whole piece logged. A streak that spans New Year's is split at the year boundary.";
-                    const started = formatStreakStart(this._yearStreak(yearQ, year));
+                    const started = formatStreakStart(agg(year).maxStreakInfo);
                     return started ? `${base}<br><br>Started: ${started}` : base;
                 }
             }
         ];
-    }
-
-    // Streak info for one year: longestRunInfo over the indices of played
-    // days in the year's gap-free day array, with the start index translated
-    // back to that day's date. The dates are read via getUTC* accessors
-    // downstream, matching how the calendar assigns days everywhere else.
-    _yearStreak(yearQ, year) {
-        const days = yearQ.get(year);
-        const played = [];
-        days.forEach((d, i) => { if (d.value > 0) played.push(i); });
-        const info = longestRunInfo(played);
-        return { ...info, start: info.start === null ? null : days[info.start].date };
     }
 
     // Fullscreen layout: the calendar transposed — days of week across the
@@ -467,8 +438,7 @@ export class CalendarComponent {
     // most recent leftmost; the container pans horizontally across years.
     renderYearGroupsVertical(container, years, config) {
         const { timeWeek, formatDay, formatMonth, formatDate, countDay, color, sessions } = config;
-        const yearQ = new Map(years);
-        const statDefs = this._yearStatDefs(yearQ, config);
+        const statDefs = this._yearStatDefs(config);
 
         // Chronological left-to-right (the shared `years` array is newest-
         // first for the horizontal layout's top-down stacking). The container

--- a/src/calendarComponent.js
+++ b/src/calendarComponent.js
@@ -1,10 +1,10 @@
 import * as d3 from "d3";
 import { getBegin, CALENDAR_CONFIG, getCssColor } from './config.js';
-import { computeAggregateStats, formatStreakStart } from './dataProcessor.js';
+import { computeAggregateStats } from './dataProcessor.js';
 import { isCurrentlyDark } from './themeManager.js';
 import { escapeHtml } from './escapeHtml.js';
 import { tooltip } from './tooltip.js';
-import { buildAggregateStatDefs, uniquePartsDesc } from './statDefs.js';
+import { buildAggregateStatDefs } from './statDefs.js';
 
 // Body of a day tooltip (date heading, piece count, plays table). Pure and
 // exported for tests: every sheet-derived cell (composer, work title, part,
@@ -118,9 +118,10 @@ export class CalendarComponent {
         // Process data for calendar view. `data` has already had partial-movement
         // entries filtered out (DataService.processData), so every count here —
         // value, weekly/monthly/yearly totals, unique pieces — is whole-pieces-only.
+        const now = new Date();
         const sessions = new Map(d3.group(data, d => d3.timeDay(d.timestamp).getTime()));
         const v = d => sessions.get(d.getTime())?.length ?? 0;
-        const days = d3.timeDay.range(getBegin(), new Date()).map(d => ({date: d, value: v(d)}));
+        const days = d3.timeDay.range(getBegin(), now).map(d => ({date: d, value: v(d)}));
 
         // Color scale for calendar. In dark mode we invert interpolateGreens
         // (high counts map to the *light* end, low counts to dark) so busy
@@ -140,10 +141,17 @@ export class CalendarComponent {
         // header — so the per-year numbers agree with the rest of the app by
         // construction. Rows are bucketed into years by the same expression
         // the grid uses for days (d3.timeDay(...).getUTCFullYear()), so the
-        // stat column can't disagree with the band it renders beside. A year
-        // slice can't span years, so the streak splits at New Year's for free.
-        const yearStats = new Map(d3.groups(data, d => d3.timeDay(d.timestamp).getUTCFullYear())
-            .map(([y, rows]) => [y, computeAggregateStats(rows)]));
+        // stat column can't disagree with the band it renders beside, and the
+        // streak is scoped to the band's slice — it splits at the band
+        // boundary (local New Year's at UTC-and-west offsets; east of UTC the
+        // grid's bands run Jan 2–Jan 1, and the split follows them). Future-
+        // dated rows are dropped to mirror the grid's day range ending today
+        // (and renderRecentStats' `timestamp <= now` upper bound); seeding
+        // from `years` gives every rendered band an entry by construction.
+        const yearRows = d3.group(data.filter(d => d.timestamp <= now),
+            d => d3.timeDay(d.timestamp).getUTCFullYear());
+        const yearStats = new Map(years.map(([y]) =>
+            [y, computeAggregateStats(yearRows.get(y) ?? [])]));
 
         const container = d3.select("#calendar");
 
@@ -365,71 +373,45 @@ export class CalendarComponent {
     // The six per-year stats (value + tooltip content), shared by the
     // horizontal layout's right-hand column and the vertical layout's
     // below-grid rows so the numbers and explanations can't drift apart.
-    // Every value reads from config.yearStats (per-year computeAggregateStats
-    // output), so these are the same six metrics — computed by the same code
-    // — as the ALL tab, Dashboard, and "Last 365 days" header. Only the
-    // tooltip copy and the current-year projections are calendar-specific.
+    // Each def wraps buildAggregateStatDefs over config.yearStats (per-year
+    // computeAggregateStats output), so the values AND the tooltip copy are
+    // single-sourced with the ALL tab, Dashboard KPI tiles, and "Last 365
+    // days" header — a metric or copy change in statDefs.js lands here too.
+    // Only the current-year projection suffixes below are calendar-specific.
     _yearStatDefs({ yearStats }) {
-        // Grid year bands can cover a data-free year; fall back to zeros.
-        const empty = computeAggregateStats([]);
-        const agg = year => yearStats.get(year) ?? empty;
-        return [
-            {
-                label: "pieces",
-                value: year => agg(year).pieces,
-                title: year => `Pieces played in ${year}`,
-                desc: year => {
-                    const base = "Total quartets logged this year. Partial-movement entries (titles containing ':', e.g. '44#1:I') don't count — only whole pieces.";
-                    const today = new Date();
-                    if (year !== today.getUTCFullYear()) return base;
-                    const elapsed = Math.max(1, dayOfYearUTC(today));
-                    const projected = Math.floor(agg(year).pieces * daysInYear(year) / elapsed);
-                    return `${base}<br><br>On track for: ${projected}`;
-                }
+        const defsFor = year => buildAggregateStatDefs(yearStats.get(year), `in ${year}`);
+        // Tooltip suffixes only the calendar shows, keyed by the def's short
+        // label so a reorder in statDefs.js can't misattach them.
+        const extras = {
+            Pieces: year => {
+                const today = new Date();
+                if (year !== today.getUTCFullYear()) return '';
+                const elapsed = Math.max(1, dayOfYearUTC(today));
+                const projected = Math.floor(yearStats.get(year).pieces * daysInYear(year) / elapsed);
+                return `On track for: ${projected}`;
             },
-            {
-                label: "unique",
-                value: year => agg(year).uniquePieces,
-                title: year => `Unique pieces played in ${year}`,
-                desc: () => "Distinct works (composer + title) logged this year. Partial-movement entries don't count, so repeats of the same piece collapse to one."
+            Days: year => {
+                const today = new Date();
+                const denom = year === today.getUTCFullYear()
+                    ? Math.max(1, dayOfYearUTC(today))
+                    : daysInYear(year);
+                const pct = (yearStats.get(year).daysPlayed / denom * 100).toFixed(1);
+                return `${pct}% of days`;
             },
-            {
-                label: "parts",
-                value: year => agg(year).uniqueParts,
-                title: year => `Unique parts played in ${year}`,
-                desc: () => uniquePartsDesc(' this year')
+        };
+        // A zero-stats template supplies the def count and short labels (the
+        // per-year defs differ only in the values interpolated).
+        return buildAggregateStatDefs(computeAggregateStats([])).map((t, i) => ({
+            // The vertical layout prints this after the bold number ("12 pieces").
+            label: t.short.toLowerCase(),
+            value: year => defsFor(year)[i].value,
+            title: year => defsFor(year)[i].title,
+            desc: year => {
+                const desc = defsFor(year)[i].desc;
+                const extra = extras[t.short]?.(year);
+                return extra ? `${desc}<br><br>${extra}` : desc;
             },
-            {
-                label: "people",
-                value: year => agg(year).uniquePeople,
-                title: year => `People played with in ${year}`,
-                desc: () => "Distinct people logged in Player 1/2/3 and the Others? column this year, after alias normalization. Short names are resolved per-instrument via PLAYER_ALIASES, so 'Jen' on violin and 'Jen' on cello can map to different people."
-            },
-            {
-                label: "days",
-                value: year => agg(year).daysPlayed,
-                title: year => `Playing days in ${year}`,
-                desc: year => {
-                    const base = "Number of distinct days this year with at least one whole piece logged. Partial movements alone don't count as a playing day.";
-                    const today = new Date();
-                    const denom = year === today.getUTCFullYear()
-                        ? Math.max(1, dayOfYearUTC(today))
-                        : daysInYear(year);
-                    const pct = (agg(year).daysPlayed / denom * 100).toFixed(1);
-                    return `${base}<br><br>${pct}% of days`;
-                }
-            },
-            {
-                label: "streak",
-                value: year => agg(year).maxStreak,
-                title: year => `Longest streak in ${year}`,
-                desc: year => {
-                    const base = "Longest run of consecutive days this year with at least one whole piece logged. A streak that spans New Year's is split at the year boundary.";
-                    const started = formatStreakStart(agg(year).maxStreakInfo);
-                    return started ? `${base}<br><br>Started: ${started}` : base;
-                }
-            }
-        ];
+        }));
     }
 
     // Fullscreen layout: the calendar transposed — days of week across the

--- a/src/dataProcessor.js
+++ b/src/dataProcessor.js
@@ -245,13 +245,12 @@ export function formatStreakStart({ count, start }) {
     return count > 1 ? `${date} (${count})` : date;
 }
 
-// Canonical unique-counting keys, shared by computeAggregateStats and the
-// calendar's per-year accumulation so the two can't drift.
+// Canonical unique-counting keys for computeAggregateStats.
 /**
  * @param {Row} d
  * @returns {string|null} key for unique-piece counting, null if untitled
  */
-export function workKey(d) {
+function workKey(d) {
     return d.work?.title ? `${d.composer}|${d.work.title}` : null;
 }
 
@@ -262,7 +261,7 @@ export function workKey(d) {
  * @param {Row} d
  * @returns {string|null} key for unique-part counting, null if untitled or partless
  */
-export function workPartKey(d) {
+function workPartKey(d) {
     const key = workKey(d);
     return key && d.part ? `${key}|${d.part}` : null;
 }

--- a/src/statDefs.js
+++ b/src/statDefs.js
@@ -1,19 +1,11 @@
 // The six aggregate stat definitions (label, short label, value, tooltip
-// title + explainer), single-sourced. Three renderers show them — the ALL
-// tab's stats row, the Dashboard's KPI tiles, and the Calendar's "Last 365
-// days" header — and before this module each carried its own verbatim copy,
-// which had already begun to drift. The per-YEAR stats column keeps its own
-// defs in CalendarComponent._yearStatDefs (different shape: per-year value
-// functions, projections).
+// title + explainer), single-sourced. Four renderers show them — the ALL
+// tab's stats row, the Dashboard's KPI tiles, the Calendar's "Last 365
+// days" header, and the Calendar's per-year stats column (which wraps
+// these per year in CalendarComponent._yearStatDefs and layers on its
+// current-year projection suffixes) — and before this module each carried
+// its own verbatim copy, which had already begun to drift.
 import { formatStreakStart } from './dataProcessor.js';
-
-// Shared with CalendarComponent._yearStatDefs — the one per-year desc that
-// isn't a year-specific rewrite, kept single-sourced so the VA2 caveat
-// can't drift. `scope` lets the calendar say "this year" like its sibling
-// descs (e.g. pass ' this year'; the leading space matters).
-export function uniquePartsDesc(scope = '') {
-    return `Distinct work + part combinations${scope}: playing the same piece on V1 and later on V2 counts twice; repeats on the same part collapse to one. Quintet/sextet second-viola (VA2) rows count separately from VA, while the VA part filter includes them — so a VA-filtered view can show more unique parts than unique pieces.`;
-}
 
 // `agg` is computeAggregateStats() output; `windowPhrase` names the slice in
 // the tooltip titles ("in the current filter", "in the last 365 days", …).
@@ -40,7 +32,7 @@ export function buildAggregateStatDefs(agg, windowPhrase = 'in the current filte
             short: 'Parts',
             value: agg.uniqueParts,
             title: `Unique parts ${windowPhrase}`,
-            desc: uniquePartsDesc(),
+            desc: 'Distinct work + part combinations: playing the same piece on V1 and later on V2 counts twice; repeats on the same part collapse to one. Quintet/sextet second-viola (VA2) rows count separately from VA, while the VA part filter includes them — so a VA-filtered view can show more unique parts than unique pieces.',
         },
         {
             label: 'Unique people',


### PR DESCRIPTION
Closes #11.

## What

The calendar's per-year stats column re-implemented the six aggregate metrics with calendar-local code: three hand-maintained per-year Sets (`yearUnique`, `yearParts`, `yearPeople`) accumulated in `createCalendar`'s `sessions.forEach` loop, plus `yearQ`-derived pieces/days/streak in `_yearStatDefs`. Now `createCalendar` groups the raw rows by year once and builds `yearStats = Map(year → computeAggregateStats(rowsForYear))`, and every def reads from that — the same six metrics, computed by the same code, as the ALL tab, Dashboard KPI tiles, and "Last 365 days" header. Net −30 lines.

Deleted outright:
- the three per-year Sets and the accumulation loop
- `_yearStreak` (the streak length/tie-count/start now come from `maxStreakInfo`, with the `formatStreakStart` tooltip wiring preserved)
- the `yearQ` day-values Map at both call sites — nothing in the defs needs it anymore; the current-year "On track for" and "% of days" projections read `agg.pieces` / `agg.daysPlayed`

## Notes

- **Year bucketing** uses `d3.timeDay(d.timestamp).getUTCFullYear()` — the exact expression the grid uses to assign days to year bands — so the stat column can't disagree with the cells it renders beside. A year slice can't span years, so the streak still splits at New Year's with no special handling.
- **Fixes the drift flagged in the issue's first comment**: the per-year streak-start tooltip previously went through a local-midnight Date while the aggregate path stores the local day in UTC fields (off-by-one at positive UTC offsets). Both paths now share one convention.
- **Sum equivalence**: the old pieces/days sums only covered days from `getBegin()` forward, but `setBegin` is the first of the month of the earliest (sorted) row, so no row falls outside — `rows.length` / `daysPlayed` match the old sums.
- A grid year band with zero rows falls back to `computeAggregateStats([])`, matching the old `?? 0` behavior.
- Issue comment 2 (fullscreen `bottomMargin` fit at ~514–527px viewports): re-checked, unchanged — still six stats, `bottomMargin` stays 108; the pre-existing overflow window in the CSS-overlay fallback remains reachable via `overflow: auto`. A fix would be a layout tweak separate from this refactor.

## Testing

- `npm test` — 279 pass
- `npm run lint`, `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)